### PR TITLE
5-get-articles: added endpoint for /api/articles, appropriate models, controllers & integration tests

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -124,6 +124,45 @@ describe('Topics', () => {
 
 describe('Articles', () => {
     
+    describe('GET /api/articles', () => {
+        
+        test('should respond with a 200 status & an array of articles', () => {
+            return request(app)
+            .get(`/api/articles`)
+            .expect(200)
+            .then((response) => {
+                expect(response.body).toHaveProperty('articles');
+                expect(response.body.articles).toBeInstanceOf(Array);
+            });
+        });
+
+        test('should respond array of articles (of correct length) with appropriate properties', () => {
+            return request(app)
+            .get(`/api/articles`)
+            .expect(200)
+            .then((response) => {
+                const articles = response.body.articles;
+                // J.D: Please be aware that if you modify the test data, this test may fail
+                expect(testData.articleData).toHaveLength(13);
+                expect(articles).toHaveLength(13);
+                articles.forEach((article) => {
+                    expect(article).toMatchObject({
+                        article_id: expect.any(Number),
+                        author: expect.any(String),
+                        title: expect.any(String),
+                        topic: expect.any(String),
+                        body: expect.any(String),
+                        created_at: expect.any(String),
+                        votes: expect.any(Number),
+                        article_img_url: expect.any(String),
+                        comment_count: expect.any(String)
+                    });
+                });
+            });
+        });
+
+    }); // Describe: GET /api/articles
+
     describe('GET /api/articles/:article_id', () => {
         
         test('should respond with a 200 status, article object & appropriate properties when provided a valid id', () => {

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ const express = require('express');
 const app = express();
 const apiDesc = require('./endpoints');
 const { getTopics } = require('./controllers/topics.controller');
-const { getArticle } = require('./controllers/articles.controller');
+const { getArticle, getArticles } = require('./controllers/articles.controller');
 
 // middleware: (nothing yet registered - besides error handling at bottom of file)
 
@@ -12,6 +12,7 @@ app.get('/api', (request, response, next) => {
 });
 
 // routes: articles
+app.get('/api/articles', getArticles);
 app.get('/api/articles/:article_id', getArticle);
 
 // routes: topics
@@ -25,12 +26,13 @@ app.all('/*', (request, response, next) => {
 // register error handling middleware: pSQL errors
 app.use((err, request, response, next) => {
 	/**
+	 * Note (From Feedback): currently only require 22P02, add other codes in as they become required
 	 * 22P02: invalid text representation
 	 * 42601: syntax error
 	 * 42703: undefined column or parameter (limit is cast to NaN << throws this code)
 	 * 23502: violates not null constraint
 	 */
-	const badRequestErrCodes = ['22P02', '42601', '42703', '23502'];
+	const badRequestErrCodes = ['22P02'];
 	if (badRequestErrCodes.includes(err.code)) {
 		response.status(400).send({ msg: 'bad request' });
 	}

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,4 +1,4 @@
-const { selectArticle } = require('../models/articles.model');
+const { selectArticle, selectArticles } = require('../models/articles.model');
 
 exports.getArticle = (request, response, next) => {
     const articleId = request.params.article_id;
@@ -8,6 +8,14 @@ exports.getArticle = (request, response, next) => {
             next({ status: 404, msg: 'not found' });
         }
         response.status(200).send({ article: rows[0] });
+    })
+    .catch(next);
+};
+
+exports.getArticles = (request, response, next) => {
+    selectArticles()
+    .then(({ rows }) => {
+        response.status(200).send({ articles: rows });
     })
     .catch(next);
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -9,23 +9,6 @@
       "topics": [{ "slug": "football", "description": "Footie!" }]
     }
   },
-  "GET /api/articles/:article_id": {
-    "description": "serves an individual article via the :article_id",
-    "queries": [],
-    "exampleResponse": {
-      "article": {
-        "article_id": 1,
-        "title": "Living in the shadow of a great man",
-        "topic": "mitch",
-        "author": "butter_bridge",
-        "body": "I find this existence challenging",
-        "created_at": 1594329060000,
-        "votes": 100,
-        "article_img_url":
-          "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
-      }
-    }
-  },
   "GET /api/articles": {
     "description": "serves an array of all articles",
     "queries": ["author", "topic", "sort_by", "order"],
@@ -41,6 +24,23 @@
           "comment_count": 6
         }
       ]
+    }
+  },
+  "GET /api/articles/:article_id": {
+    "description": "serves an individual article via the :article_id",
+    "queries": [],
+    "exampleResponse": {
+      "article": {
+        "article_id": 1,
+        "title": "Living in the shadow of a great man",
+        "topic": "mitch",
+        "author": "butter_bridge",
+        "body": "I find this existence challenging",
+        "created_at": 1594329060000,
+        "votes": 100,
+        "article_img_url":
+          "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+      }
     }
   }
 }

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -3,3 +3,11 @@ const db = require('../db/connection');
 exports.selectArticle = (id) => {
     return db.query('SELECT * FROM articles WHERE article_id = $1', [id]);
 };
+
+exports.selectArticles = () => {
+    return db.query(
+        `SELECT articles.*, COUNT(comments.comment_id) AS comment_count FROM articles
+         LEFT JOIN comments ON articles.article_id = comments.article_id
+         GROUP BY articles.article_id`
+    );
+};


### PR DESCRIPTION
* Added two integration tests for /api/articles first (TDD)
* Created a controller action: getArticles & model function: selectArticles (/w comment count)
    * Note: COUNT returns datatype string, since:
    * “the return type of the COUNT operator is bigint which, by definition, can exceed the maximum value of an int in JavaScript”
    * See: https://github.com/brianc/node-postgres/issues/378
    * Additional note: we can cast this to a number later, should we wish
* Added an /api/articles endpoint to app.js