### PR TITLE
app now allows for patch requests to increment votes

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -241,6 +241,115 @@ describe('Articles', () => {
 
     }); // Describe: GET /api/article/:article_id
 
+    describe('PATCH /api/articles/:article_id', () => {
+        
+        test('should accept a body of form { inc_votes: x }, updates correct article by x votes & responds /w updated obj', () => {
+            // arrange
+            const articleId = 2;
+            const patchBody = { inc_votes: 42 };
+            // act
+            return request(app)
+            .patch(`/api/articles/${articleId}`)
+            .send(patchBody)
+            .expect(200)
+            .then((response) => {
+                // assert
+                expect(response.body).toHaveProperty('article');
+                expect(response.body.article).toHaveProperty('votes', 42);
+                expect(response.body.article).toMatchObject({
+                    article_id: expect.any(Number),
+                    title: expect.any(String),
+                    topic: expect.any(String),
+                    author: expect.any(String),
+                    body: expect.any(String),
+                    created_at: expect.any(String),
+                    votes: expect.any(Number),
+                    article_img_url: expect.any(String)
+                });
+            });
+        });
+
+        test('should also function as expected with negative numbers (decrement the vote count)', () => {
+            // arrange
+            const articleId = 2;
+            const patchBody = { inc_votes: -42 };
+            // act
+            return request(app)
+            .patch(`/api/articles/${articleId}`)
+            .send(patchBody)
+            .expect(200)
+            .then((response) => {
+                // assert
+                expect(response.body.article).toHaveProperty('votes', -42);
+            });
+        });
+
+        test('should respond with a 404 not found if the article id is valid, but does not exist', () => {
+            // arrange
+            const articleId = 999;
+            const patchBody = { inc_votes: 42 };
+            // act
+            return request(app)
+            .patch(`/api/articles/${articleId}`)
+            .send(patchBody)
+            .expect(404)
+            .then((response) => {
+                // assert
+                expect(response.body).toHaveProperty('msg');
+                expect(response.body.msg).toBe('not found');
+            });
+        });
+
+        test('should respond with a 400 bad request if the article id is invalid', () => {
+            // arrange
+            const articleId = "this-is-not-an-article-id";
+            const patchBody = { inc_votes: 42 };
+            // act
+            return request(app)
+            .patch(`/api/articles/${articleId}`)
+            .send(patchBody)
+            .expect(400)
+            .then((response) => {
+                // assert
+                expect(response.body).toHaveProperty('msg');
+                expect(response.body.msg).toBe('bad request');
+            });
+        });
+
+        test('should respond with a 400 bad request if the payload value is invalid', () => {
+            // arrange
+            const articleId = 2;
+            const patchBody = { inc_votes: 'not-a-number' };
+            // act
+            return request(app)
+            .patch(`/api/articles/${articleId}`)
+            .send(patchBody)
+            .expect(400)
+            .then((response) => {
+                // assert
+                expect(response.body).toHaveProperty('msg');
+                expect(response.body.msg).toBe('bad request');
+            });
+        });
+
+        test('should respond with a 400 bad request if the payload key is invalid', () => {
+            // arrange
+            const articleId = 2;
+            const patchBody = { invalid_key: 42 };
+            // act
+            return request(app)
+            .patch(`/api/articles/${articleId}`)
+            .send(patchBody)
+            .expect(400)
+            .then((response) => {
+                // assert
+                expect(response.body).toHaveProperty('msg');
+                expect(response.body.msg).toBe('bad request');
+            });
+        });
+
+    });
+
 }); // Describe: Articles
 
 describe('Comments', () => {

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ const express = require('express');
 const app = express();
 const apiDesc = require('./endpoints');
 const { getTopics } = require('./controllers/topics.controller');
-const { getArticle, getArticles } = require('./controllers/articles.controller');
+const { getArticle, getArticles, patchArticleVotes } = require('./controllers/articles.controller');
 const { getCommentsByArticleId, postComment } = require('./controllers/comments.controller');
 
 // middleware
@@ -16,6 +16,7 @@ app.get('/api', (request, response, next) => {
 // routes: articles
 app.get('/api/articles', getArticles);
 app.get('/api/articles/:article_id', getArticle);
+app.patch('/api/articles/:article_id', patchArticleVotes);
 
 // routes: comments
 app.get('/api/articles/:article_id/comments', getCommentsByArticleId);
@@ -38,7 +39,7 @@ app.use((err, request, response, next) => {
 	 * 42703: undefined column or parameter (limit is cast to NaN << throws this code)
 	 * 23502: violates not null constraint
 	 */
-	const badRequestErrCodes = ['22P02'];
+	const badRequestErrCodes = ['22P02', '23502'];
 	if (badRequestErrCodes.includes(err.code)) {
 		response.status(400).send({ msg: 'bad request' });
 	}

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -1,4 +1,4 @@
-const { selectArticle, selectArticles } = require('../models/articles.model');
+const { selectArticle, selectArticles, updateArticleVotes } = require('../models/articles.model');
 
 exports.getArticle = (request, response, next) => {
     const articleId = request.params.article_id;
@@ -16,6 +16,21 @@ exports.getArticles = (request, response, next) => {
     return selectArticles()
     .then(({ rows }) => {
         response.status(200).send({ articles: rows });
+    })
+    .catch(next);
+};
+
+exports.patchArticleVotes = (request, response, next) => {
+    const articleId = request.params.article_id;
+    const voteCount = request.body.inc_votes;
+    return selectArticle(articleId)
+    .then(({ rows }) => {
+        return (rows.length === 0)
+            ? Promise.reject({ status: 404, msg: 'not found' })
+            : updateArticleVotes(articleId, voteCount);
+    })
+    .then(({ rows }) => {
+        response.status(200).send({ article: rows[0] });
     })
     .catch(next);
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -83,5 +83,22 @@
         "article_id": 42
       }
     }
+  },
+  "PATCH /api/articles/:article_id": {
+    "description": "accepts a body consisting of a vote count to increment an article by through the :article_id",
+    "body": {
+      "inc_votes": 42
+    },
+    "exampleResponse": {
+      "article": {
+        "article_id": 999,
+        "title": "Seafood substitutions are increasing",
+        "topic": "cooking",
+        "author": "weegembump",
+        "created_at": "2018-05-30T15:59:13.341Z",
+        "votes": 0,
+        "comment_count": 6
+      }
+    }
   }
 }

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -20,3 +20,12 @@ exports.selectArticles = () => {
          ORDER BY articles.created_at DESC`
     );
 };
+
+exports.updateArticleVotes = (id, voteCount) => {
+    return db.query(`
+        UPDATE articles
+        SET votes = votes + $1
+        WHERE article_id = $2
+        RETURNING *
+    `, [voteCount, id]);
+};


### PR DESCRIPTION
* Created integration tests for PATCH /api/articles/:article_id
* Included new endpoint (route) on app.js: PATCH /api/articles/:article_id
* Added controller & model code to allow article votes to be updated
* Updated endpoints.json to serve up-to-date information via /api