### PR TITLE
Task 12: /api/articles/:article_id now also returns comment count

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -243,8 +243,22 @@ describe('Articles', () => {
                      * TODO: could extend custom matcher: toBeValid<Request|APIEndpoint|...> to accept URL
                      * + others & use to validate article_img_url, amongst other things.
                      */
-                    article_img_url: expect.any(String)
+                    article_img_url: expect.any(String),
+                    comment_count: expect.any(Number)
                 });
+            });
+        });
+
+        test('should respond with the appropriate number of comments within comment_count', () => {
+            // arrange
+            const articleId = 9;
+            // act
+            return request(app)
+            .get(`/api/articles/${articleId}`)
+            .expect(200)
+            .then((response) => {
+                // assert
+                expect(response.body.article).toHaveProperty('comment_count', 2);
             });
         });
 

--- a/controllers/comments.controller.js
+++ b/controllers/comments.controller.js
@@ -1,4 +1,4 @@
-const { selectArticle } = require("../models/articles.model");
+const { selectArticle, checkArticleExists } = require("../models/articles.model");
 const { selectCommentsByArticleId, insertComment, deleteCommentById } = require("../models/comments.model");
 const { selectUserByUsername } = require("../models/users.model");
 
@@ -25,7 +25,7 @@ exports.postComment = (request, response, next) => {
     }
     return selectUserByUsername(username)
     .then((result) => {
-        return selectArticle(articleId);
+        return checkArticleExists(articleId);
     })
     .then((result) => {
         return insertComment(articleId, username, body);

--- a/endpoints.json
+++ b/endpoints.json
@@ -39,7 +39,8 @@
         "created_at": 1594329060000,
         "votes": 100,
         "article_img_url":
-          "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
+          "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        "comment_count": 0
       }
     }
   },


### PR DESCRIPTION
* Modified tests to expect comment_count on /api/articles/:article_id tests
* Altered SQL query (in selectArticle)
* updated endpoints information
* _Note: weird error would occasionally occur (deadlock detected), this was intermittent; separating out checkArticleExists seems to have fixed it, but since the error was intermittent, I can't check for sure. I got the tests passing several times before committing changes._